### PR TITLE
remove Twitter's old endpoint

### DIFF
--- a/count-shares/javascript (nodejs)/count-shares/README.md
+++ b/count-shares/javascript (nodejs)/count-shares/README.md
@@ -5,7 +5,6 @@ Returns JSON with a number of shares for a URL.
 ```
 {
     "facebook": 5461703,
-    "twitter": 11876867,
     "vk": 2462,
     "odnoklassniki": 547,
     "pinterest": 60,
@@ -27,6 +26,8 @@ countShares.get( 'http://google.com', function( err, result ) {  } );
 
 `url`: {String} full URL. `www.domain.com` and `domain.com` are different websites for Twitter and Odnoklassniki.
 
+Twitter's old endpoint `http://urls.api.twitter.com/1/urls/count.json?url=` stopped work on November 20th, 2015, and according to <a href="https://twittercommunity.com/t/how-to-get-proper-twitter-share-count-for-a-url/53876/2">this post</a> there are no plans to replace it with anything in the short term.
+
 `callback( err, result )`: {Function} callback that will get the results and errors (if any)
 
-`networks`: (optional) {Array} or {String} available networks: facebook, twitter, linkedin, odnoklassniki, pinterest, vk (vkontakte). Need more? <a href="https://github.com/clexit/social-widgets">Contribute!</a>
+`networks`: (optional) {Array} or {String} available networks: facebook, linkedin, odnoklassniki, pinterest, vk (vkontakte). Need more? <a href="https://github.com/clexit/social-widgets">Contribute!</a>

--- a/count-shares/javascript (nodejs)/count-shares/libs/networks.js
+++ b/count-shares/javascript (nodejs)/count-shares/libs/networks.js
@@ -27,12 +27,13 @@ module.exports = {
         }
     },
 
-    twitter: {
-        url  : 'http://urls.api.twitter.com/1/urls/count.json?url=',
-        parse: function( res ) {
-            return JSON.parse( res ).count / 1;
-        }
-    },
+    // https://twittercommunity.com/t/how-to-get-proper-twitter-share-count-for-a-url/53876/2
+    //twitter: {
+    //    url  : 'http://urls.api.twitter.com/1/urls/count.json?url=',
+    //    parse: function( res ) {
+    //        return JSON.parse( res ).count / 1;
+    //    }
+    //},
 
     vk: {
         url  : 'http://vk.com/share.php?act=count&url=',

--- a/count-shares/javascript (nodejs)/count-shares/tests/index.js
+++ b/count-shares/javascript (nodejs)/count-shares/tests/index.js
@@ -20,22 +20,22 @@ countShares.get('http://google.com', function( err ) {
 
 
 // should handle incorrect spelling
-countShares.get('http://google.com', function( err, result ) {
+countShares.get('http://google.com', function( err ) {
     assert.ok( typeof err === 'string' );
-}, 'Twitdter');
+}, 'facebok');
 
 
 // should be case insensitive
 countShares.get('http://google.com', function( err, result ) {
-    assert.ok( typeof result.twitter !== 'undefined' );
-}, 'Twitter');
+    assert.ok( typeof result.facebook !== 'undefined' );
+}, 'Facebook');
 
 
 // should handle Arrays
 countShares.get('http://google.com', function( err, result ) {
-    assert.ok( typeof result.twitter !== 'undefined' );
     assert.ok( typeof result.facebook !== 'undefined' );
-}, [ 'Twitter', 'facebook' ]);
+    assert.ok( typeof result.vk !== 'undefined' );
+}, [ 'facebook', 'vk' ]);
 
 
 // should handle empty "networks" argument


### PR DESCRIPTION
Twitter closed old endpoint `http://urls.api.twitter.com/1/urls/count.json?url=` on November 20th, 2015 and according to <a href="https://twittercommunity.com/t/how-to-get-proper-twitter-share-count-for-a-url/53876/2">this post</a> there are no plans to replace it with anything in the short term.