### PR TITLE
Fix for crashes when scrapping a huge list of URLs

### DIFF
--- a/count-shares/javascript (nodejs)/count-shares/libs/get.js
+++ b/count-shares/javascript (nodejs)/count-shares/libs/get.js
@@ -20,7 +20,11 @@ module.exports = function( url, callback, networks ) {
     var requests = getRequests( url, networks );
 
     getBunch.getMulti(requests, function( results ) {
-        callback( null, parseResults(results) );
+        try {
+          callback( null, parseResults( results ) );
+        } catch(err){
+          callback( err, null );
+        }
         return;
     })
 }


### PR DESCRIPTION
I've been using your module to get share counts of hundreds of URLs in a loop and It highlighted some problems with the facebook graph API. There is apparently a limit of API calls one can do without an accessToken. This limit is not clearly defined in the doc (but I found some approximative values here : http://stackoverflow.com/a/14223029)

When the limit is reached, the API return a 403 status code with no JSON output. Therefore the JSON.parse method (located here : https://github.com/clexit/social-widgets/blob/master/count-shares/javascript%20(nodejs)/count-shares/libs/networks.js#L5) throw an error that is not handled by the module. I fixed that in my only commit.

-----

**The next steps I wanted to take** was to implement a way to pass an accessToken to the module in order to potentially increase the API calls limit. But I finally managed to reduce my loop aggressiveness to an acceptable degree.

**For those facing the same problem :** I used a delay of 750 milliseconds between each calls and when I reach the limit, I pause the loop for 30 seconds and then continue (even do I never reach that limit with a 750 milliseconds delay. I was reaching it sometimes with a 500 milliseconds delay)

An other approach would have been to implement a way to batch requests to reduce the amount of calls... but that complexity is not required with delays :)