### PR TITLE
Change facebook implementation because FQL is not available anymore

### DIFF
--- a/count-shares/javascript (nodejs)/count-shares/README.md
+++ b/count-shares/javascript (nodejs)/count-shares/README.md
@@ -17,14 +17,23 @@ Returns JSON with a number of shares for a URL.
 ```
 var countShares = require( 'count-shares' );
 
-countShares.get( 'http://google.com', function( err, result ) {  } );
+countShares.get( {
+    url: 'http://google.com',
+    accessTokens: {
+        fb: 'foobar'
+    }
+}, function( err, result ) {  } );
 ```
 
 ## Methods
 
-### get( url, callback[, networks] )
+### get( conf, callback[, networks] )
 
-`url`: {String} full URL. `www.domain.com` and `domain.com` are different websites for Twitter and Odnoklassniki.
+`conf`: {Object} An object defining config needed to make requests to different APIs.
+
+`conf.url`: {String} full URL. `www.domain.com` and `domain.com` are different websites for Twitter and Odnoklassniki.
+
+`conf.accessTokens.fb`: {String} a valid facebook access token
 
 Twitter's old endpoint `http://urls.api.twitter.com/1/urls/count.json?url=` stopped work on November 20th, 2015, and according to <a href="https://twittercommunity.com/t/how-to-get-proper-twitter-share-count-for-a-url/53876/2">this post</a> there are no plans to replace it with anything in the short term.
 

--- a/count-shares/javascript (nodejs)/count-shares/libs/get.js
+++ b/count-shares/javascript (nodejs)/count-shares/libs/get.js
@@ -2,14 +2,25 @@ var getBunch = require( 'get-bunch' ),
     NETWORKS = require( './networks' );
 
 
-module.exports = function( url, callback, networks ) {
+module.exports = function( conf, callback, networks ) {
+    // NOTE: the first parameter of this function was a URL string until >1.1.1
+    // so we do this for backward compatibility reasons :
+    if (typeof conf === 'string') {
+        conf = { url: conf }
+    }
+
+    if ( typeof conf.url !== 'string' ) {
+        console.error( 'ERROR: count-shares: url is required' );
+        return { 'error': true, 'message': 'missing url' };
+    }
+
     if ( typeof callback !== 'function' ) {
         console.error( 'ERROR: count-shares: callback function is required' );
         return { 'error': true, 'message': 'missing callback' };
     }
 
-    if ( !isValidURL(url) ) {
-        invalidURL( url, callback );
+    if ( !isValidURL(conf.url) ) {
+        invalidURL( conf.url, callback );
         return;
     }
 
@@ -17,7 +28,7 @@ module.exports = function( url, callback, networks ) {
     if ( !networks ) return;
 
 
-    var requests = getRequests( url, networks );
+    var requests = getRequests( conf, networks );
 
     getBunch.getMulti(requests, function( results ) {
         try {
@@ -84,14 +95,14 @@ function filterNetworks( networks, callback ) {
 }
 
 
-function getRequests( url, networks ) {
+function getRequests( conf, networks ) {
     var requests = [];
 
     networks.map(function( network ) {
 
         requests.push({
             name: network,
-            url : NETWORKS[ network ].url + ( (network==='facebook')?"'"+url+"'":url ),
+            url : NETWORKS[ network ].url(conf),
             type: 'plain'
         });
     });

--- a/count-shares/javascript (nodejs)/count-shares/libs/get.js
+++ b/count-shares/javascript (nodejs)/count-shares/libs/get.js
@@ -9,6 +9,11 @@ module.exports = function( conf, callback, networks ) {
         conf = { url: conf }
     }
 
+    if ( typeof conf !== 'object' ) {
+        console.error( 'ERROR: count-shares: conf is required' );
+        return { 'error': true, 'message': 'missing conf' };
+    }
+
     if ( typeof conf.url !== 'string' ) {
         console.error( 'ERROR: count-shares: url is required' );
         return { 'error': true, 'message': 'missing url' };

--- a/count-shares/javascript (nodejs)/count-shares/libs/networks.js
+++ b/count-shares/javascript (nodejs)/count-shares/libs/networks.js
@@ -1,42 +1,63 @@
 module.exports = {
     facebook: {
-        url  : 'http://graph.facebook.com/fql?q=SELECT%20url,%20normalized_url,%20share_count,%20like_count,%20comment_count,%20total_count,commentsbox_count,%20comments_fbid,%20click_count%20FROM%20link_stat%20WHERE%20url=',
+        url: function( conf ) {
+            // doc here : https://developers.facebook.com/docs/graph-api/reference/v2.7/url
+            var url = 'https://graph.facebook.com/v2.7/?id='+conf.url;
+            var accessToken = typeof conf.accessTokens === 'object' && typeof conf.accessTokens.fb === 'string' ? conf.accessTokens.fb : null;
+
+            if ( accessToken ) {
+                url += '&access_token='+accessToken;
+            }
+
+            return url;
+        },
         parse: function( res ) {
-            return JSON.parse( res ).data[ 0 ][ 'total_count' ] / 1;
+            var obj = JSON.parse( res );
+            return typeof obj.share === 'object' && typeof obj.share.share_count === 'number' ? obj.share.share_count / 1 : 0;
         }
     },
 
     linkedin: {
-        url  : 'https://www.linkedin.com/countserv/count/share?format=json&url=',
+        url: function( conf ) {
+            return 'https://www.linkedin.com/countserv/count/share?format=json&url='+conf.url;
+        },
         parse: function( res ) {
             return JSON.parse( res ).count / 1;
         }
     },
 
     odnoklassniki: {
-        url  : 'https://connect.ok.ru/dk?st.cmd=extLike&uid=odklcnt0&ref=',
+        url: function( conf ) {
+            return 'https://connect.ok.ru/dk?st.cmd=extLike&uid=odklcnt0&ref='+conf.url;
+        },
         parse: function( res ) {
             return res.match( /^ODKL\.updateCount\(\'odklcnt0\',\'(\d+)\'\);$/ )[ 1 ] / 1;
         }
     },
 
     pinterest: {
-        url : 'http://api.pinterest.com/v1/urls/count.json?url=',
+        url: function( conf ) {
+            return 'http://api.pinterest.com/v1/urls/count.json?url='+conf.url;
+        },
         parse: function( res ) {
             return JSON.parse(res.match(/receiveCount\((.*?)\)$/)[1]).count / 1;
         }
     },
 
     // https://twittercommunity.com/t/how-to-get-proper-twitter-share-count-for-a-url/53876/2
-    //twitter: {
-    //    url  : 'http://urls.api.twitter.com/1/urls/count.json?url=',
-    //    parse: function( res ) {
-    //        return JSON.parse( res ).count / 1;
-    //    }
-    //},
+    // twitter: {
+    //     url: function( conf ) {
+    //         return 'http://urls.api.twitter.com/1/urls/count.json?url='+conf.url;
+    //     },
+    //     parse: function( res ) {
+    //         return JSON.parse( res ).count / 1;
+    //     }
+    // },
 
     vk: {
-        url  : 'http://vk.com/share.php?act=count&url=',
+        url: function( conf ) {
+            return 'http://vk.com/share.php?act=count&url='+conf.url;
+        },
         parse: function( res ) {
             return res.match( /^VK\.Share\.count\(\d, (\d+)\);$/ )[ 1 ] / 1;
         }

--- a/count-shares/javascript (nodejs)/count-shares/tests/index.js
+++ b/count-shares/javascript (nodejs)/count-shares/tests/index.js
@@ -2,6 +2,10 @@ var assert      = require( 'assert' ),
     countShares = require( '../index' ),
     NETWORKS    = require( '../libs/networks' );
 
+if (typeof process.env.FACEBOOK_ACCESS_TOKEN === 'undefined') {
+  console.warn('WARN: You should set the FACEBOOK_ACCESS_TOKEN env variable to a valid access token in order for everything to work.');
+}
+
 
 // missing callback
 assert.ok( countShares.get().error );
@@ -22,24 +26,29 @@ countShares.get('http://google.com', function( err ) {
 // should handle incorrect spelling
 countShares.get('http://google.com', function( err ) {
     assert.ok( typeof err === 'string' );
-}, 'facebok');
+}, 'pintarest');
 
 
 // should be case insensitive
 countShares.get('http://google.com', function( err, result ) {
-    assert.ok( typeof result.facebook !== 'undefined' );
-}, 'Facebook');
+    assert.ok( typeof result.pinterest !== 'undefined' );
+}, 'PinteResT');
 
 
 // should handle Arrays
 countShares.get('http://google.com', function( err, result ) {
-    assert.ok( typeof result.facebook !== 'undefined' );
+    assert.ok( typeof result.pinterest !== 'undefined' );
     assert.ok( typeof result.vk !== 'undefined' );
-}, [ 'facebook', 'vk' ]);
+}, [ 'pinterest', 'vk' ]);
 
 
 // should handle empty "networks" argument
-countShares.get('http://google.com', function( err, result ) {
+countShares.get({
+  url: 'http://google.com',
+  accessTokens: {
+    fb: process.env.FACEBOOK_ACCESS_TOKEN
+  }
+}, function( err, result ) {
     for ( var key in NETWORKS ) {
         assert.ok( typeof result[ key ] !== undefined );
     }
@@ -47,7 +56,12 @@ countShares.get('http://google.com', function( err, result ) {
 
 
 // should return correct data type
-countShares.get('http://google.com', function( err, result ) {
+countShares.get({
+  url: 'http://google.com',
+  accessTokens: {
+    fb: process.env.FACEBOOK_ACCESS_TOKEN
+  }
+}, function( err, result ) {
     for ( var key in result ) {
         assert.ok( typeof result[ key ] === 'number' );
         assert.ok( result[ key ] > 0 );


### PR DESCRIPTION
Hello again @clexit !

The Facebook Query Language (FQL) is no longer available since August 8, 2016 :scream: (as stated here : https://developers.facebook.com/docs/reference/fql/ )

So I decided to implement an equivalent with the last version of the API (v2.7), and realized that an accesToken is now required to get share counts (check this exemple call : https://graph.facebook.com/v2.7/?id=http://google.com). I checked if there where an other older version that don't require an accessToken, but they all behave the same since v2.1.

...So I had to implement an accessToken config ! I basically implemented what you suggested here : https://github.com/clexit/social-widgets/pull/9#issuecomment-238854543.

I updated the readme and the tests. You now have to define the `FACEBOOK_ACCESS_TOKEN` env variable when running the tests. (`FACEBOOK_ACCESS_TOKEN='foobar' npm test`). (you can get an accesToken quickly there : https://developers.facebook.com/tools/explorer/)